### PR TITLE
feat: add Docker and Makefile tooling for telegram-support-bot

### DIFF
--- a/examples/telegram-support-bot/Dockerfile
+++ b/examples/telegram-support-bot/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "main.py"]

--- a/examples/telegram-support-bot/Makefile
+++ b/examples/telegram-support-bot/Makefile
@@ -1,0 +1,20 @@
+.PHONY: install run test docker-up docker-down docker-logs
+
+install:
+	python -m venv .venv
+	.venv/bin/pip install -r requirements.txt
+
+run:
+	.venv/bin/python main.py
+
+test:
+	.venv/bin/pytest
+
+docker-up:
+	docker compose up -d --build
+
+docker-down:
+	docker compose down
+
+docker-logs:
+	docker compose logs -f bot

--- a/examples/telegram-support-bot/docker-compose.yml
+++ b/examples/telegram-support-bot/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  bot:
+    build: .
+    env_file:
+      - .env
+    volumes:
+      - support-db:/app/support.db
+    restart: unless-stopped
+
+volumes:
+  support-db:


### PR DESCRIPTION
## Summary

- Add `Dockerfile` using `python:3.12-slim`, installs deps from `requirements.txt`, runs `main.py`
- Add `docker-compose.yml` with `bot` service, `.env` file mount, `support.db` named volume, and `restart: unless-stopped`
- Add `Makefile` with targets: `install`, `run`, `test`, `docker-up`, `docker-down`, `docker-logs`

Closes #4

## Test plan

- [ ] `make install` creates venv and installs requirements
- [ ] `make run` launches the bot locally
- [ ] `make test` runs pytest
- [ ] `make docker-up` builds and starts the container in detached mode
- [ ] `make docker-logs` tails bot container logs
- [ ] `make docker-down` stops the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)