### PR TITLE
feat: add Telegram admin panel (admin commands + inline keyboard UI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,6 @@ SUPPORT_CHAT_ID=-1001234567890
 
 # Path to the SQLite database file (default: support.db in the working directory)
 DATABASE_PATH=support.db
+
+# Comma-separated Telegram user IDs with admin access
+ADMIN_IDS=123456789,987654321

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from os import getenv
 
 from dotenv import load_dotenv
@@ -11,6 +11,7 @@ class Config:
     bot_token: str
     support_chat_id: int
     database_path: str
+    admin_ids: list[int] = field(default_factory=list)
 
 
 def load_config() -> Config:
@@ -22,8 +23,11 @@ def load_config() -> Config:
     if not support_chat_id:
         raise ValueError("SUPPORT_CHAT_ID environment variable is required")
 
+    admin_ids = [int(x) for x in getenv("ADMIN_IDS", "").split(",") if x]
+
     return Config(
         bot_token=token,
         support_chat_id=int(support_chat_id),
         database_path=getenv("DATABASE_PATH", "support.db"),
+        admin_ids=admin_ids,
     )

--- a/bot/db/queries.py
+++ b/bot/db/queries.py
@@ -27,6 +27,11 @@ CREATE TABLE IF NOT EXISTS user_settings (
     user_id  INTEGER PRIMARY KEY,
     language TEXT NOT NULL DEFAULT 'en'
 );
+
+CREATE TABLE IF NOT EXISTS banned_users (
+    user_id   INTEGER PRIMARY KEY,
+    banned_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
 """
 
 
@@ -135,3 +140,84 @@ async def set_user_language(db_path: str, user_id: int, language: str) -> None:
             (user_id, language),
         )
         await db.commit()
+
+
+# ── Admin queries ─────────────────────────────────────────────────────────────
+
+
+async def get_all_tickets(
+    db_path: str,
+    status: str,
+    limit: int,
+    offset: int,
+) -> list[dict]:
+    """Return paginated tickets filtered by status."""
+    async with aiosqlite.connect(db_path) as db:
+        db.row_factory = aiosqlite.Row
+        async with db.execute(
+            "SELECT * FROM tickets WHERE status = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
+            (status, limit, offset),
+        ) as cursor:
+            rows = await cursor.fetchall()
+            return [dict(r) for r in rows]
+
+
+async def get_ticket_count_by_status(db_path: str) -> dict:
+    """Return a dict with counts: total, open, resolved."""
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute(
+            "SELECT status, COUNT(*) FROM tickets GROUP BY status"
+        ) as cursor:
+            rows = await cursor.fetchall()
+
+    counts: dict[str, int] = {}
+    for status, count in rows:
+        counts[status] = count
+    counts["total"] = sum(counts.values())
+    return counts
+
+
+async def get_unique_user_ids(db_path: str) -> list[int]:
+    """Return list of unique user_ids from the tickets table."""
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute("SELECT DISTINCT user_id FROM tickets") as cursor:
+            rows = await cursor.fetchall()
+            return [row[0] for row in rows]
+
+
+async def get_last_24h_count(db_path: str) -> int:
+    """Return count of tickets created in the last 24 hours."""
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute(
+            "SELECT COUNT(*) FROM tickets WHERE created_at >= datetime('now', '-1 day')"
+        ) as cursor:
+            row = await cursor.fetchone()
+            return row[0] if row else 0
+
+
+async def ban_user(db_path: str, user_id: int) -> None:
+    """Add a user to the banned_users table (idempotent)."""
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute(
+            "INSERT OR IGNORE INTO banned_users (user_id) VALUES (?)", (user_id,)
+        )
+        await db.commit()
+
+
+async def unban_user(db_path: str, user_id: int) -> bool:
+    """Remove a user from the banned_users table. Returns True if they were banned."""
+    async with aiosqlite.connect(db_path) as db:
+        cursor = await db.execute(
+            "DELETE FROM banned_users WHERE user_id = ?", (user_id,)
+        )
+        await db.commit()
+        return cursor.rowcount > 0
+
+
+async def is_banned(db_path: str, user_id: int) -> bool:
+    """Return True if the user is in the banned_users table."""
+    async with aiosqlite.connect(db_path) as db:
+        async with db.execute(
+            "SELECT 1 FROM banned_users WHERE user_id = ?", (user_id,)
+        ) as cursor:
+            return await cursor.fetchone() is not None

--- a/bot/handlers/admin.py
+++ b/bot/handlers/admin.py
@@ -1,0 +1,334 @@
+"""Admin panel handlers — accessible only to configured admin users.
+
+Filters (F.from_user.id.in_(admin_ids)) are applied in main.py after the
+config is loaded, before this router is included in the dispatcher.
+"""
+
+import logging
+
+from aiogram import F, Router
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+from aiogram.types import CallbackQuery, Message
+
+from bot.db import queries
+from bot.keyboards.admin import (
+    admin_menu_keyboard,
+    stats_keyboard,
+    ticket_view_keyboard,
+    tickets_list_keyboard,
+)
+from bot.states.admin import AdminBroadcast, AdminReply
+
+logger = logging.getLogger(__name__)
+
+PER_PAGE = 5
+
+router = Router()
+
+
+# ── /admin — Main menu ────────────────────────────────────────────────────────
+
+
+@router.message(Command("admin"))
+async def cmd_admin(message: Message) -> None:
+    await message.answer("🛠 Admin Panel", reply_markup=admin_menu_keyboard())
+
+
+@router.callback_query(F.data == "admin:menu")
+async def cb_admin_menu(callback: CallbackQuery) -> None:
+    await callback.message.edit_text(  # type: ignore[union-attr]
+        "🛠 Admin Panel", reply_markup=admin_menu_keyboard()
+    )
+    await callback.answer()
+
+
+# ── Tickets list ──────────────────────────────────────────────────────────────
+
+
+async def _send_tickets_page(
+    db_path: str,
+    status: str,
+    page: int,
+    target: Message | CallbackQuery,
+) -> None:
+    counts = await queries.get_ticket_count_by_status(db_path)
+    total = counts.get(status, 0)
+    tickets = await queries.get_all_tickets(db_path, status, PER_PAGE, page * PER_PAGE)
+
+    if not tickets:
+        text = f"No {status} tickets."
+    else:
+        lines = [f"<b>Tickets ({status}) — page {page + 1}</b>"]
+        for t in tickets:
+            username = f"@{t['username']}" if t["username"] else str(t["user_id"])
+            lines.append(
+                f"<b>#{t['id']}</b> | {username} | {t['subject']} | {t['created_at'][:10]}"
+            )
+        text = "\n".join(lines)
+
+    keyboard = tickets_list_keyboard(tickets, status, page, total, PER_PAGE)
+    if isinstance(target, Message):
+        await target.answer(text, reply_markup=keyboard, parse_mode="HTML")
+    else:
+        await target.message.edit_text(  # type: ignore[union-attr]
+            text, reply_markup=keyboard, parse_mode="HTML"
+        )
+        await target.answer()
+
+
+@router.message(Command("tickets"))
+async def cmd_tickets(message: Message, db_path: str) -> None:
+    args = (message.text or "").split()
+    status = args[1] if len(args) > 1 and args[1] in ("open", "resolved") else "open"
+    await _send_tickets_page(db_path, status, 0, message)
+
+
+@router.callback_query(F.data.startswith("admin:tickets:"))
+async def cb_tickets(callback: CallbackQuery, db_path: str) -> None:
+    parts = (callback.data or "").split(":")
+    status = parts[2]
+    page = int(parts[3])
+    await _send_tickets_page(db_path, status, page, callback)
+
+
+# ── Single ticket view ────────────────────────────────────────────────────────
+
+
+@router.callback_query(F.data.startswith("admin:view:"))
+async def cb_view_ticket(callback: CallbackQuery, db_path: str) -> None:
+    parts = (callback.data or "").split(":")
+    ticket_id = int(parts[2])
+    status = parts[3]
+    page = int(parts[4])
+
+    ticket = await queries.get_ticket(db_path, ticket_id)
+    if not ticket:
+        await callback.answer(f"Ticket #{ticket_id} not found.", show_alert=True)
+        return
+
+    username = f"@{ticket['username']}" if ticket["username"] else str(ticket["user_id"])
+    text = (
+        f"<b>Ticket #{ticket['id']}</b>\n"
+        f"User: {username} (ID: {ticket['user_id']})\n"
+        f"Subject: {ticket['subject']}\n"
+        f"Status: {ticket['status']}\n"
+        f"Created: {ticket['created_at']}\n"
+    )
+    if ticket["resolved_at"]:
+        text += f"Resolved: {ticket['resolved_at']}\n"
+    text += f"\n{ticket['body']}"
+
+    await callback.message.edit_text(  # type: ignore[union-attr]
+        text,
+        reply_markup=ticket_view_keyboard(ticket_id, ticket["status"], page),
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+# ── Reply flow ────────────────────────────────────────────────────────────────
+
+
+@router.callback_query(F.data.startswith("admin:reply:"))
+async def cb_reply_start(callback: CallbackQuery, state: FSMContext) -> None:
+    ticket_id = int((callback.data or "").split(":")[2])
+    await state.set_state(AdminReply.waiting_reply)
+    await state.update_data(ticket_id=ticket_id)
+    await callback.message.answer(  # type: ignore[union-attr]
+        f"Send your reply for ticket #{ticket_id}:"
+    )
+    await callback.answer()
+
+
+@router.message(AdminReply.waiting_reply)
+async def process_admin_reply(
+    message: Message,
+    state: FSMContext,
+    db_path: str,
+) -> None:
+    if not message.text:
+        await message.answer("Please send a text message.")
+        return
+
+    data = await state.get_data()
+    ticket_id: int = data["ticket_id"]
+    await state.clear()
+
+    ticket = await queries.get_ticket(db_path, ticket_id)
+    if not ticket:
+        await message.answer(f"Ticket #{ticket_id} not found.")
+        return
+
+    agent_id = message.from_user.id  # type: ignore[union-attr]
+    await queries.add_reply(db_path, ticket_id, agent_id, message.text)
+
+    try:
+        await message.bot.send_message(  # type: ignore[union-attr]
+            ticket["user_id"],
+            f"📬 <b>Reply to your ticket #{ticket_id}</b>\n\n{message.text}",
+            parse_mode="HTML",
+        )
+        await message.answer(f"Reply sent to user for ticket #{ticket_id}.")
+    except Exception:
+        logger.warning(
+            "Could not notify user %d about reply to ticket #%d",
+            ticket["user_id"],
+            ticket_id,
+        )
+        await message.answer(
+            f"Reply recorded for ticket #{ticket_id}, but could not notify the user."
+        )
+
+
+# ── Resolve via inline button ─────────────────────────────────────────────────
+
+
+@router.callback_query(F.data.startswith("admin:resolve:"))
+async def cb_resolve_ticket(callback: CallbackQuery, db_path: str) -> None:
+    ticket_id = int((callback.data or "").split(":")[2])
+    updated = await queries.resolve_ticket(db_path, ticket_id)
+
+    if not updated:
+        await callback.answer(
+            f"Ticket #{ticket_id} not found or already resolved.", show_alert=True
+        )
+        return
+
+    ticket = await queries.get_ticket(db_path, ticket_id)
+    try:
+        if ticket:
+            await callback.bot.send_message(  # type: ignore[union-attr]
+                ticket["user_id"],
+                f"✅ Your ticket #{ticket_id} has been resolved. "
+                "Thank you for contacting support!",
+            )
+    except Exception:
+        logger.warning("Could not notify user about resolution of ticket #%d", ticket_id)
+
+    await callback.answer(f"Ticket #{ticket_id} resolved.", show_alert=True)
+    await callback.message.edit_text(  # type: ignore[union-attr]
+        f"✅ Ticket #{ticket_id} has been resolved."
+    )
+
+
+# ── /stats ────────────────────────────────────────────────────────────────────
+
+
+async def _build_stats_text(db_path: str) -> str:
+    counts = await queries.get_ticket_count_by_status(db_path)
+    user_ids = await queries.get_unique_user_ids(db_path)
+    last_24h = await queries.get_last_24h_count(db_path)
+
+    total = counts.get("total", 0)
+    open_count = counts.get("open", 0)
+    resolved_count = counts.get("resolved", 0)
+
+    return (
+        "📊 <b>Bot Statistics</b>\n"
+        f"Total tickets: {total}\n"
+        f"Open: {open_count}\n"
+        f"Resolved: {resolved_count}\n"
+        f"Users served: {len(user_ids)}\n"
+        f"Last 24h: {last_24h} new tickets"
+    )
+
+
+@router.message(Command("stats"))
+async def cmd_stats(message: Message, db_path: str) -> None:
+    await message.answer(await _build_stats_text(db_path), parse_mode="HTML")
+
+
+@router.callback_query(F.data == "admin:stats")
+async def cb_stats(callback: CallbackQuery, db_path: str) -> None:
+    await callback.message.edit_text(  # type: ignore[union-attr]
+        await _build_stats_text(db_path),
+        reply_markup=stats_keyboard(),
+        parse_mode="HTML",
+    )
+    await callback.answer()
+
+
+# ── /broadcast ────────────────────────────────────────────────────────────────
+
+
+async def _do_broadcast(message: Message, db_path: str, text: str) -> None:
+    user_ids = await queries.get_unique_user_ids(db_path)
+    sent = 0
+    failed = 0
+    for uid in user_ids:
+        try:
+            await message.bot.send_message(uid, text)  # type: ignore[union-attr]
+            sent += 1
+        except Exception:
+            failed += 1
+    await message.answer(f"Broadcast sent to {sent} users ({failed} failed).")
+
+
+@router.message(Command("broadcast"))
+async def cmd_broadcast(message: Message, db_path: str) -> None:
+    parts = (message.text or "").split(maxsplit=1)
+    if len(parts) < 2:
+        await message.answer("Usage: /broadcast <message>")
+        return
+    await _do_broadcast(message, db_path, parts[1])
+
+
+@router.callback_query(F.data == "admin:broadcast")
+async def cb_broadcast_start(callback: CallbackQuery, state: FSMContext) -> None:
+    await state.set_state(AdminBroadcast.waiting_text)
+    await callback.message.answer(  # type: ignore[union-attr]
+        "Enter the broadcast message to send to all users:"
+    )
+    await callback.answer()
+
+
+@router.message(AdminBroadcast.waiting_text)
+async def process_broadcast(
+    message: Message,
+    state: FSMContext,
+    db_path: str,
+) -> None:
+    if not message.text:
+        await message.answer("Please send a text message.")
+        return
+    await state.clear()
+    await _do_broadcast(message, db_path, message.text)
+
+
+# ── /ban & /unban ─────────────────────────────────────────────────────────────
+
+
+@router.message(Command("ban"))
+async def cmd_ban(message: Message, db_path: str) -> None:
+    parts = (message.text or "").split()
+    if len(parts) < 2 or not parts[1].isdigit():
+        await message.answer("Usage: /ban <user_id>")
+        return
+    user_id = int(parts[1])
+    await queries.ban_user(db_path, user_id)
+    await message.answer(f"User {user_id} has been banned.")
+    logger.info("Admin banned user %d", user_id)
+
+
+@router.message(Command("unban"))
+async def cmd_unban(message: Message, db_path: str) -> None:
+    parts = (message.text or "").split()
+    if len(parts) < 2 or not parts[1].isdigit():
+        await message.answer("Usage: /unban <user_id>")
+        return
+    user_id = int(parts[1])
+    removed = await queries.unban_user(db_path, user_id)
+    if removed:
+        await message.answer(f"User {user_id} has been unbanned.")
+        logger.info("Admin unbanned user %d", user_id)
+    else:
+        await message.answer(f"User {user_id} was not banned.")
+
+
+@router.callback_query(F.data == "admin:ban")
+async def cb_ban_prompt(callback: CallbackQuery) -> None:
+    await callback.message.answer(  # type: ignore[union-attr]
+        "To ban a user send: /ban <user_id>\nTo unban: /unban <user_id>"
+    )
+    await callback.answer()

--- a/bot/keyboards/admin.py
+++ b/bot/keyboards/admin.py
@@ -1,0 +1,70 @@
+from aiogram.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+
+def admin_menu_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(text="📋 All Tickets", callback_data="admin:tickets:open:0"),
+                InlineKeyboardButton(text="📊 Stats", callback_data="admin:stats"),
+            ],
+            [
+                InlineKeyboardButton(text="📢 Broadcast", callback_data="admin:broadcast"),
+                InlineKeyboardButton(text="🚫 Ban User", callback_data="admin:ban"),
+            ],
+        ]
+    )
+
+
+def tickets_list_keyboard(
+    tickets: list[dict],
+    status: str,
+    page: int,
+    total: int,
+    per_page: int = 5,
+) -> InlineKeyboardMarkup:
+    buttons: list[list[InlineKeyboardButton]] = []
+
+    for t in tickets:
+        buttons.append([
+            InlineKeyboardButton(
+                text=f"View #{t['id']}",
+                callback_data=f"admin:view:{t['id']}:{status}:{page}",
+            )
+        ])
+
+    nav_row: list[InlineKeyboardButton] = []
+    if page > 0:
+        nav_row.append(
+            InlineKeyboardButton(text="← Prev", callback_data=f"admin:tickets:{status}:{page - 1}")
+        )
+    if (page + 1) * per_page < total:
+        nav_row.append(
+            InlineKeyboardButton(text="Next →", callback_data=f"admin:tickets:{status}:{page + 1}")
+        )
+    if nav_row:
+        buttons.append(nav_row)
+
+    buttons.append([InlineKeyboardButton(text="⬅ Back", callback_data="admin:menu")])
+    return InlineKeyboardMarkup(inline_keyboard=buttons)
+
+
+def ticket_view_keyboard(ticket_id: int, status: str, page: int) -> InlineKeyboardMarkup:
+    rows: list[list[InlineKeyboardButton]] = []
+    if status == "open":
+        rows.append([
+            InlineKeyboardButton(text="Reply", callback_data=f"admin:reply:{ticket_id}"),
+            InlineKeyboardButton(text="Resolve", callback_data=f"admin:resolve:{ticket_id}"),
+        ])
+    rows.append([
+        InlineKeyboardButton(text="Back to list", callback_data=f"admin:tickets:{status}:{page}")
+    ])
+    return InlineKeyboardMarkup(inline_keyboard=rows)
+
+
+def stats_keyboard() -> InlineKeyboardMarkup:
+    return InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="⬅ Back", callback_data="admin:menu")]
+        ]
+    )

--- a/bot/main.py
+++ b/bot/main.py
@@ -3,14 +3,15 @@
 import asyncio
 import logging
 
-from aiogram import Bot, Dispatcher
+from aiogram import Bot, Dispatcher, F
 from aiogram.client.default import DefaultBotProperties
 from aiogram.enums import ParseMode
 from aiogram.fsm.storage.memory import MemoryStorage
 
 from bot.config import load_config
 from bot.db.queries import init_db
-from bot.handlers import support, user
+from bot.handlers import admin, support, user
+from bot.middlewares.ban_check import BanCheckMiddleware
 from bot.middlewares.i18n import I18nMiddleware
 
 logging.basicConfig(
@@ -37,6 +38,20 @@ async def main() -> None:
 
     dp.update.middleware(I18nMiddleware())
 
+    # Restrict admin router to configured admin user IDs
+    admin_ids = set(config.admin_ids)
+    admin.router.message.filter(F.from_user.id.in_(admin_ids))
+    admin.router.callback_query.filter(F.from_user.id.in_(admin_ids))
+
+    # BanCheckMiddleware runs before all user and support handlers.
+    # It is NOT applied to the admin router so admins are never blocked.
+    ban_middleware = BanCheckMiddleware()
+    user.router.message.middleware(ban_middleware)
+    user.router.callback_query.middleware(ban_middleware)
+    support.router.message.middleware(ban_middleware)
+
+    # Admin router is included first so its filters take priority
+    dp.include_router(admin.router)
     dp.include_router(user.router)
     dp.include_router(support.router)
 

--- a/bot/middlewares/ban_check.py
+++ b/bot/middlewares/ban_check.py
@@ -1,0 +1,33 @@
+"""Middleware that blocks banned users from interacting with user handlers."""
+
+from typing import Any, Awaitable, Callable
+
+from aiogram import BaseMiddleware
+from aiogram.types import CallbackQuery, Message, TelegramObject
+
+from bot.db import queries
+
+
+class BanCheckMiddleware(BaseMiddleware):
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        user = None
+        if isinstance(event, (Message, CallbackQuery)):
+            user = event.from_user
+
+        if user:
+            db_path: str | None = data.get("db_path")
+            if db_path and await queries.is_banned(db_path, user.id):
+                if isinstance(event, Message):
+                    await event.answer("You are not allowed to use this bot.")
+                elif isinstance(event, CallbackQuery):
+                    await event.answer(
+                        "You are not allowed to use this bot.", show_alert=True
+                    )
+                return
+
+        return await handler(event, data)

--- a/bot/states/admin.py
+++ b/bot/states/admin.py
@@ -1,0 +1,9 @@
+from aiogram.fsm.state import State, StatesGroup
+
+
+class AdminReply(StatesGroup):
+    waiting_reply = State()
+
+
+class AdminBroadcast(StatesGroup):
+    waiting_text = State()

--- a/tests/test_admin_queries.py
+++ b/tests/test_admin_queries.py
@@ -1,0 +1,134 @@
+"""Tests for admin-specific DB queries in bot/db/queries.py."""
+
+import pytest
+import pytest_asyncio
+
+from bot.db.queries import (
+    ban_user,
+    create_ticket,
+    get_all_tickets,
+    get_last_24h_count,
+    get_ticket_count_by_status,
+    get_unique_user_ids,
+    init_db,
+    is_banned,
+    resolve_ticket,
+    unban_user,
+)
+
+
+@pytest_asyncio.fixture
+async def db(tmp_path):
+    """Yield an initialised temporary SQLite database path."""
+    path = str(tmp_path / "test.db")
+    await init_db(path)
+    return path
+
+
+@pytest.mark.asyncio
+async def test_get_all_tickets_paginated(db):
+    """get_all_tickets returns correct pages."""
+    for i in range(7):
+        await create_ticket(db, user_id=i, username=f"user{i}", subject=f"S{i}", body="body")
+
+    page1 = await get_all_tickets(db, "open", limit=5, offset=0)
+    assert len(page1) == 5
+
+    page2 = await get_all_tickets(db, "open", limit=5, offset=5)
+    assert len(page2) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_all_tickets_status_filter(db):
+    """get_all_tickets filters by status correctly."""
+    id1 = await create_ticket(db, user_id=1, username="a", subject="S1", body="B1")
+    await create_ticket(db, user_id=2, username="b", subject="S2", body="B2")
+    await resolve_ticket(db, id1)
+
+    open_tickets = await get_all_tickets(db, "open", limit=10, offset=0)
+    resolved_tickets = await get_all_tickets(db, "resolved", limit=10, offset=0)
+
+    assert len(open_tickets) == 1
+    assert len(resolved_tickets) == 1
+    assert open_tickets[0]["subject"] == "S2"
+    assert resolved_tickets[0]["subject"] == "S1"
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_count_by_status(db):
+    """get_ticket_count_by_status returns correct counts."""
+    id1 = await create_ticket(db, user_id=1, username="a", subject="S1", body="B1")
+    await create_ticket(db, user_id=2, username="b", subject="S2", body="B2")
+    await resolve_ticket(db, id1)
+
+    counts = await get_ticket_count_by_status(db)
+    assert counts["open"] == 1
+    assert counts["resolved"] == 1
+    assert counts["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_get_ticket_count_empty_db(db):
+    """get_ticket_count_by_status returns zeros for an empty database."""
+    counts = await get_ticket_count_by_status(db)
+    assert counts.get("open", 0) == 0
+    assert counts.get("resolved", 0) == 0
+    assert counts.get("total", 0) == 0
+
+
+@pytest.mark.asyncio
+async def test_get_unique_user_ids(db):
+    """get_unique_user_ids returns distinct user IDs only."""
+    await create_ticket(db, user_id=10, username="x", subject="S1", body="B1")
+    await create_ticket(db, user_id=10, username="x", subject="S2", body="B2")
+    await create_ticket(db, user_id=20, username="y", subject="S3", body="B3")
+
+    user_ids = await get_unique_user_ids(db)
+    assert set(user_ids) == {10, 20}
+    assert len(user_ids) == 2
+
+
+@pytest.mark.asyncio
+async def test_get_last_24h_count(db):
+    """Newly created tickets are counted in the last 24h window."""
+    await create_ticket(db, user_id=1, username="u", subject="S", body="B")
+    count = await get_last_24h_count(db)
+    assert count >= 1
+
+
+@pytest.mark.asyncio
+async def test_ban_user(db):
+    """ban_user marks a user as banned."""
+    assert not await is_banned(db, 42)
+    await ban_user(db, 42)
+    assert await is_banned(db, 42)
+
+
+@pytest.mark.asyncio
+async def test_ban_user_idempotent(db):
+    """Banning the same user twice does not raise an error."""
+    await ban_user(db, 99)
+    await ban_user(db, 99)  # should not raise
+    assert await is_banned(db, 99)
+
+
+@pytest.mark.asyncio
+async def test_unban_user(db):
+    """unban_user removes the ban and returns True."""
+    await ban_user(db, 42)
+    result = await unban_user(db, 42)
+    assert result is True
+    assert not await is_banned(db, 42)
+
+
+@pytest.mark.asyncio
+async def test_unban_not_banned(db):
+    """unban_user returns False when the user was not banned."""
+    result = await unban_user(db, 999)
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_is_banned_false_for_new_user(db):
+    """is_banned returns False for users never banned."""
+    assert not await is_banned(db, 1234567)


### PR DESCRIPTION
## Summary

Implements the fully-featured admin panel for the Telegram support bot as described in issue #9.

- **`ADMIN_IDS` config**: Loaded from the `ADMIN_IDS` env var (comma-separated user IDs); documented in `.env.example`
- **Admin router** (`handlers/admin.py`): Filtered to admin users only via `F.from_user.id.in_(admin_ids)` applied in `main.py`
- **`/admin`**: Main menu inline keyboard with All Tickets, Stats, Broadcast, Ban User buttons
- **`/tickets [status]`**: Paginated ticket list (5/page) with per-ticket View buttons and Prev/Next navigation; status filter (`open`/`resolved`)
- **Ticket view**: Full ticket details with Reply and Resolve inline buttons
- **Reply flow**: FSM (`AdminReply`) — bot prompts for reply text, sends to the user, records in `ticket_replies`
- **`/stats`**: Accurate counts (total, open, resolved, users served, last 24 h)
- **`/broadcast <msg>`**: Sends to all known users, reports success/fail count; also available via inline FSM flow
- **`/ban <user_id>` / `/unban <user_id>`**: Manage the `banned_users` table
- **`BanCheckMiddleware`**: Registered on `user.router` and `support.router` (not admin) — banned users receive a rejection message
- **New DB queries**: `get_all_tickets`, `get_ticket_count_by_status`, `get_unique_user_ids`, `get_last_24h_count`, `ban_user`, `unban_user`, `is_banned`
- **`banned_users` table** added to schema via `CREATE TABLE IF NOT EXISTS`

## Test plan

- [x] 11 new tests in `tests/test_admin_queries.py` cover all new DB functions (pagination, status filter, unique users, 24 h count, ban/unban/is_banned)
- [x] Existing 8 tests in `tests/test_queries.py` still pass (19/19 total)
- [ ] Deploy with `ADMIN_IDS` set and verify `/admin` menu appears only for listed user IDs
- [ ] Verify banned users see rejection message on any command/callback
- [ ] Verify `/broadcast` delivers to all users and reports counts

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)